### PR TITLE
Create MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ITHS Java23 https://github.com/fungover/thunder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 
 
-## Description:
+## Description
 Leveraging MQTT and Shelly smart home devices to seamlessly control a lamp's on/off functionality within a smart home setup.
 
 ## Installation
@@ -36,5 +36,8 @@ Leveraging MQTT and Shelly smart home devices to seamlessly control a lamp's on/
 ...needs to be updated later on in the project..
 "Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space."
 
-
+## Licensing
+This software is licensed under the MIT License, allowing you to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software under the following conditions:
++ Include the original copyright message and the MIT License in all copies or substantial portions of the software.
+For more details, refer to the [MIT License](LICENSE) file.
 


### PR DESCRIPTION
Add a MIT License

### Related Issue(s)
Closes issue #12

### Proposed Changes

- **Change 1**:  Add a MIT License to the project
- **Change 2**: Add a section in the README.md about licensing

### Description
Added a MIT License that allows developers to use, modify, and distribute the software under the only condition that the copyright message of the license and the license itself is "included in all
copies or substantial portions of the Software".

### Checklist
- [ ] Code compiles correctly
- [ ] Extended the README / documentation, if necessary
- [ ] Added tests to cover new changes
- [ ] All new and existing tests passed
- [ ] The code follows the code style of this project

### Additional Details
As for the question if libraries and tools we are using have any restrictive licenses, I found The Apache License, Version 2.0, Eclipse Public License v2.0, and a MIT License for the mockito-core. I am unsure whethere we have to add these licenses to our project as third-party licenses.