### PR TITLE
18 handling disconnect

### DIFF
--- a/src/main/java/org/fungover/thunder/ClientHandler.java
+++ b/src/main/java/org/fungover/thunder/ClientHandler.java
@@ -30,6 +30,10 @@ public class ClientHandler {
                 }else{
                     connection.close();
                 }
+                if (packageReader.isCleanDisconnect(connection)){
+                    clients.remove(connection);
+                    connection.close();
+                }
             }
         }
     }

--- a/src/main/java/org/fungover/thunder/ClientHandler.java
+++ b/src/main/java/org/fungover/thunder/ClientHandler.java
@@ -24,10 +24,11 @@ public class ClientHandler {
             } else {
                 clientSocket.close();
             }
-            while (!clientSocket.isClosed()) {
+            while (clients.contains(clientSocket)) {
                 if (packageReader.isCleanDisconnect(clientSocket)){
                     clientSocket.close();
                     clients.remove(clientSocket);
+                    break;
                 }
             }
             removeDisconnectedClients();

--- a/src/main/java/org/fungover/thunder/ClientHandler.java
+++ b/src/main/java/org/fungover/thunder/ClientHandler.java
@@ -25,8 +25,10 @@ public class ClientHandler {
                 clientSocket.close();
             }
             while (!clientSocket.isClosed()) {
-                //Logic to read from or disconnect client.
-                break;
+                if (packageReader.isCleanDisconnect(clientSocket)){
+                    clientSocket.close();
+                    clients.remove(clientSocket);
+                }
             }
             removeDisconnectedClients();
         } catch (Exception e) {
@@ -42,10 +44,6 @@ public class ClientHandler {
                 if (client.isClosed()) {
                     System.out.println("Client disconnected: " + client.getInetAddress().getHostName());
                     iterator.remove();
-                }
-                if (packageReader.isCleanDisconnect(connection)){
-                    connection.close();
-                    clients.remove(connection);
                 }
             }
         }

--- a/src/main/java/org/fungover/thunder/ClientHandler.java
+++ b/src/main/java/org/fungover/thunder/ClientHandler.java
@@ -31,8 +31,8 @@ public class ClientHandler {
                     connection.close();
                 }
                 if (packageReader.isCleanDisconnect(connection)){
-                    clients.remove(connection);
                     connection.close();
+                    clients.remove(connection);
                 }
             }
         }

--- a/src/main/java/org/fungover/thunder/PackageReader.java
+++ b/src/main/java/org/fungover/thunder/PackageReader.java
@@ -56,7 +56,7 @@ public class PackageReader {
     public boolean isCleanDisconnect(Socket socket) throws IOException {
         InetAddress client = socket.getInetAddress();
 
-        if (!connectPackageSent.containsKey(client)){
+        if (isClientConnected(client)){
             return false;
         }
 
@@ -70,5 +70,9 @@ public class PackageReader {
             return true;
         }
         return false;
+    }
+
+    private boolean isClientConnected(InetAddress client) {
+        return !connectPackageSent.containsKey(client);
     }
 }

--- a/src/main/java/org/fungover/thunder/PackageReader.java
+++ b/src/main/java/org/fungover/thunder/PackageReader.java
@@ -62,7 +62,6 @@ public class PackageReader {
 
         if (isDisconnectPackage(bytesRead, buffer)) {
             System.out.println("Received MQTT DISCONNECT message from client");
-            connectPackageSent.put(socket.getInetAddress(), true);
             connectPackageSent.remove(client);
             return true;
         }

--- a/src/main/java/org/fungover/thunder/PackageReader.java
+++ b/src/main/java/org/fungover/thunder/PackageReader.java
@@ -44,4 +44,28 @@ public class PackageReader {
     private static boolean isConnectPackage(int bytesRead, byte[] buffer) {
         return bytesRead > 0 && buffer[0] == (byte) 0x10;
     }
+
+    private static boolean isDisconnectPackage(int bytesRead, byte[] buffer){
+        return bytesRead > 0 && buffer[0] == (byte) 0xE0;
+    }
+
+    public boolean isCleanDisconnect(Socket socket) throws IOException {
+        InetAddress client = socket.getInetAddress();
+
+        if (!connectPackageSent.containsKey(client)){
+            return false;
+        }
+
+        InputStream inputStream = socket.getInputStream();
+        byte[] buffer = new byte[1024];
+        int bytesRead = inputStream.read(buffer);
+
+        if (isDisconnectPackage(bytesRead, buffer)) {
+            System.out.println("Received MQTT DISCONNECT message from client");
+            connectPackageSent.put(socket.getInetAddress(), true);
+            connectPackageSent.remove(client);
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/test/java/org/fungover/thunder/ClientHandlerTest.java
+++ b/src/test/java/org/fungover/thunder/ClientHandlerTest.java
@@ -8,9 +8,9 @@ import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ClientHandlerTest {
     ClientHandler clientHandler;
@@ -23,19 +23,20 @@ class ClientHandlerTest {
     }
 
     @Test
-    @DisplayName("Return 1 if valid client is added")
-    void return1IfValidClientIsAdded() throws IOException {
+    @DisplayName("Return 0 if valid client is added and then disconnected")
+    void return0IfValidClientIsAddedAndThenDisconnected() throws IOException {
         Socket socketMock = mock(Socket.class);
         InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 1883);
         when(socketMock.getInetAddress()).thenReturn(inetSocketAddress.getAddress());
-        InputStream in = new ByteArrayInputStream(new byte[]{0x10});
+        InputStream connectPacket = new ByteArrayInputStream(new byte[]{0x10});
+        InputStream disconnectPacket = new ByteArrayInputStream(new byte[]{(byte) 0xE0});
         OutputStream out = new ByteArrayOutputStream();
         when(socketMock.getOutputStream()).thenReturn(out);
-        when(socketMock.getInputStream()).thenReturn(in);
-        when(packageReader.isValidConnection(socketMock)).thenReturn(true);
+        when(socketMock.getInputStream()).thenReturn(connectPacket,disconnectPacket);
+
         clientHandler.handleConnection(socketMock);
 
-        assertEquals(1,clientHandler.getClients().size());
+        assertEquals(0,clientHandler.getClients().size());
     }
     
     @Test
@@ -45,10 +46,8 @@ class ClientHandlerTest {
         InetSocketAddress inetSocketAddress = new InetSocketAddress("localhost", 1883);
         when(socketMock.getInetAddress()).thenReturn(inetSocketAddress.getAddress());
         InputStream in = new ByteArrayInputStream(new byte[]{0x20});
-        OutputStream out = new ByteArrayOutputStream();
-        when(socketMock.getOutputStream()).thenReturn(out);
         when(socketMock.getInputStream()).thenReturn(in);
-        when(packageReader.isValidConnection(socketMock)).thenReturn(true);
+
         clientHandler.handleConnection(socketMock);
 
         assertEquals(0,clientHandler.getClients().size());

--- a/src/test/java/org/fungover/thunder/PackageReaderTest.java
+++ b/src/test/java/org/fungover/thunder/PackageReaderTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.net.Socket;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -82,5 +83,40 @@ class PackageReaderTest {
         byte[] bytesWritten = outputStream.toByteArray();
 
         assertEquals(0, bytesWritten.length);
+    }
+    @Test
+    @DisplayName("Should return true when client send disconnect package")
+    void shouldReturnTrueWhenClientSendDisconnectPackage() throws IOException{
+        Socket socketMock = mock(Socket.class);
+        setUpConnection(socketMock);
+        InputStream inputStream = new ByteArrayInputStream(new byte[]{(byte) 0xE0,0x00});
+        when(socketMock.getInputStream()).thenReturn(inputStream);
+
+        assertThat(packageReader.isCleanDisconnect(socketMock)).isTrue();
+    }
+    @Test
+    @DisplayName("Should return false if there was no connection prior to disconnect")
+    void shouldReturnFalseIfThereWasNoConnectionPriorToDisconnect() throws IOException {
+        Socket socketMock = mock(Socket.class);
+        InputStream inputStream = new ByteArrayInputStream(new byte[]{(byte) 0xE0,0x00});
+        when(socketMock.getInputStream()).thenReturn(inputStream);
+
+        assertThat(packageReader.isCleanDisconnect(socketMock)).isFalse();
+    }
+    @Test
+    @DisplayName("Should return false if isCleanDisconnect() is called without disconnectPackage")
+    void shouldReturnFalseIfIsCleanDisconnectIsCalledWithoutDisconnectPackage() throws IOException {
+        Socket socketMock = mock(Socket.class);
+        setUpConnection(socketMock);
+
+        assertThat(packageReader.isCleanDisconnect(socketMock)).isFalse();
+    }
+    void setUpConnection(Socket socketMock) throws IOException {
+        InputStream inputStream = new ByteArrayInputStream(new byte[]{0x10, 0x01, 0x00});
+        OutputStream outputStream = new ByteArrayOutputStream();
+        when(socketMock.getInputStream()).thenReturn(inputStream);
+        when(socketMock.getOutputStream()).thenReturn(outputStream);
+
+        packageReader.isValidConnection(socketMock);
     }
 }


### PR DESCRIPTION
### Related Issue(s)
Closes #18

### Proposed Changes
- Add detection for disconnect package PackageReader
- Add methodcall and closing+removal of connection when DISCONNECT package is sent from Client.
- Add tests for disconnect

### Description
Add a way to detect DISCONNECT packages sent from Client. When this is detected, the Socket will be closed and the connection will be removed from the broker. You can now disconnect and reconnect to the broker.