### PR TITLE
Update maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
   merge_group:
+    types: [checks_requested]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
[Make sure to run CI when a PR is added to merge queue. ](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)


<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 313f4fe750a6f9d4478e7bdf9a4a0f638f931e86.  | 
|--------|--------|

### Summary:
This PR updates the CI pipeline configuration to trigger a build and run checks when a PR is added to the merge queue.

**Key points**:
- Modified `.github/workflows/maven.yml` to add a `merge_group` trigger.
- Added a `checks_requested` trigger under `merge_group`.
- These changes ensure the CI pipeline runs when a PR is added to the merge queue.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)
<!--
ELLIPSIS_HIDDEN
-->
